### PR TITLE
#40 - Create github action workflow to prevent PR merge without Label

### DIFF
--- a/.github/workflows/check-PR-labels.yml
+++ b/.github/workflows/check-PR-labels.yml
@@ -1,0 +1,24 @@
+name: "Check Labels on PR"
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  check-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Verify PR has at least one label"
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              core.setFailed("This event is not associated with a pull request.");
+            }
+            const labels = pr.labels;
+            if (!labels || labels.length === 0) {
+              core.setFailed("Merge blocked: Please add at least one label to your pull request.");
+            } else {
+              console.log(`PR has ${labels.length} label(s).`);
+            }

--- a/.github/workflows/check-PR-labels.yml
+++ b/.github/workflows/check-PR-labels.yml
@@ -2,7 +2,8 @@ name: "Check Labels on PR"
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+  workflow_dispatch: # this is to allow manual triggering somehow :/
 
 jobs:
   check-labels:


### PR DESCRIPTION
Created a PR label check workflow to ensure no PR is merged without a label

Issue: #40