### PR TITLE
#140 - Add functionality to update trip member roles

### DIFF
--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -74,7 +74,7 @@ model TripMember {
   tripId Int
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId String
-  role   String @default("member")
+  role   String @default("member") // Possible values: "creator", "admin", "member"
 
   @@id([tripId, userId])
 }

--- a/server/src/controllers/member.controller.ts
+++ b/server/src/controllers/member.controller.ts
@@ -1,0 +1,74 @@
+import { Request, Response } from 'express';
+import { updateTripMember, getTripMember } from '../models/member.model.ts';
+import { AuthenticatedRequest } from '../interfaces/interfaces.ts';
+import { handleControllerError } from '../utils/errorHandlers.ts';
+
+/**
+ * Update just trip member role for now until some other fields are added.
+ * - The trip **creator** can change any member’s role.
+ * - An **admin** can only update a **member's** role (not other admins or the creator).
+ */
+export const updateTripMemberHandler = async (req: Request, res: Response) => {
+  try {
+    const { userId } = req as AuthenticatedRequest;
+    const tripId = Number(req.params.tripId);
+    const targetUserId = req.params.userId; // The user whose role is being updated
+    const { role } = req.body;
+
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized Request' });
+      return;
+    }
+
+    if (isNaN(tripId)) {
+      res.status(400).json({ error: 'Invalid trip ID' });
+      return;
+    }
+
+    if (!role || !['admin', 'member'].includes(role)) {
+      res.status(400).json({ error: 'Invalid role update request' });
+      return;
+    }
+
+    // Fetch the requester’s role
+    const requestingMember = await getTripMember(tripId, userId);
+    if (!requestingMember) {
+      res.status(403).json({ error: 'You are not a member of this trip' });
+      return;
+    }
+
+    // Fetch the target member
+    const targetMember = await getTripMember(tripId, targetUserId);
+    if (!targetMember) {
+      res.status(404).json({ error: 'Target member not found in this trip' });
+      return;
+    }
+
+    // Permission checks
+    if (requestingMember.role === 'creator') {
+      // The creator can update any role
+    } else if (requestingMember.role === 'admin') {
+      if (targetMember.role !== 'member') {
+        res.status(403).json({ error: 'Admins can only update member roles' });
+        return;
+      }
+    } else {
+      res
+        .status(403)
+        .json({ error: 'Only admins and creators can update roles' });
+      return;
+    }
+
+    // Perform update
+    const updatedMember = await updateTripMember(tripId, targetUserId, {
+      role,
+    });
+
+    res.status(200).json({
+      message: `Member role updated successfully`,
+      member: updatedMember,
+    });
+  } catch (error) {
+    handleControllerError(error, res, 'Error updating trip member:');
+  }
+};

--- a/server/src/interfaces/interfaces.ts
+++ b/server/src/interfaces/interfaces.ts
@@ -4,6 +4,7 @@ export interface AuthenticatedRequest extends Request {
   userId: string;
 }
 
+// Trip Interfaces
 export interface CreateTripInput {
   name: string;
   description?: string;
@@ -18,9 +19,15 @@ export interface CreateTripInput {
 export interface UpdateTripInput
   extends Partial<Omit<CreateTripInput, 'createdBy'>> {}
 
+// Invitation Interfaces
 export interface CreateInviteInput {
   tripId: number;
   email: string;
   createdBy: string;
   invitedUserId?: string;
+}
+
+// Member Interfaces
+export interface UpdateTripMemberInput {
+  role?: 'admin' | 'member';
 }

--- a/server/src/middleware/member.validators.ts
+++ b/server/src/middleware/member.validators.ts
@@ -1,0 +1,14 @@
+import { param, body, checkExact } from 'express-validator';
+
+export const validateUpdateTripMemberInput = checkExact([
+  param('tripId')
+    .isInt({ min: 1 })
+    .withMessage('Trip ID must be a positive number'),
+  param('userId')
+    .isString()
+    .notEmpty()
+    .withMessage("Member's userId is required"),
+  body('role')
+    .isIn(['admin', 'member'])
+    .withMessage('Role must be either "admin" or "member"'),
+]);

--- a/server/src/models/member.model.ts
+++ b/server/src/models/member.model.ts
@@ -1,6 +1,7 @@
 import { PrismaPromise } from '@prisma/client';
 import prisma from '../config/prismaClient.ts';
 import { handlePrismaError } from '../utils/errorHandlers.ts';
+import { UpdateTripMemberInput } from '../interfaces/interfaces.ts';
 
 // Get tripMember by tripId and userId
 export const getTripMember = async (tripId: number, userId: string) => {
@@ -70,9 +71,18 @@ export const addTripMember = (
   }
 };
 
-export default {
-  getTripMember,
-  getManyTripMembers,
-  getManyTripMembersFilteredByUserId,
-  addTripMember,
+export const updateTripMember = async (
+  tripId: number,
+  userId: string,
+  updateData: UpdateTripMemberInput,
+) => {
+  try {
+    return await prisma.tripMember.update({
+      where: { tripId_userId: { tripId, userId } },
+      data: updateData,
+    });
+  } catch (error) {
+    console.error('Error updating trip member:', error);
+    throw handlePrismaError(error);
+  }
 };

--- a/server/src/routes/appRouter.ts
+++ b/server/src/routes/appRouter.ts
@@ -1,12 +1,14 @@
 import express from 'express';
 import tripRouter from './trip.routes.ts';
 import expenseRouter from './expense.routes.ts';
-import inviteRouter from './invitee.routes.ts'
+import inviteRouter from './invitee.routes.ts';
+import memberRouter from './member.routes.ts';
 
 const router = express.Router();
 
 router.use('/trips', tripRouter);
 router.use('/trips/:tripId/expenses', expenseRouter);
 router.use('/trips/:tripId/invites', inviteRouter);
+router.use('/trips/:tripId/members', memberRouter);
 
 export default router;

--- a/server/src/routes/member.routes.ts
+++ b/server/src/routes/member.routes.ts
@@ -1,0 +1,19 @@
+import express from 'express';
+import validationErrorHandler from '../middleware/validationErrorHandler.ts';
+import { authMiddleware } from '../middleware/authMiddleware.ts';
+import { validateUpdateTripMemberInput } from '../middleware/member.validators.ts';
+import { updateTripMemberHandler } from '../controllers/member.controller.ts';
+
+const router = express.Router({ mergeParams: true });
+
+router
+  //  Trip Expense CRUD routes
+  .patch(
+    '/:userId',
+    validateUpdateTripMemberInput,
+    validationErrorHandler,
+    authMiddleware,
+    updateTripMemberHandler,
+  );
+
+export default router;

--- a/server/src/tests/unit/member.tests/member.controller.test.ts
+++ b/server/src/tests/unit/member.tests/member.controller.test.ts
@@ -1,0 +1,131 @@
+import { updateTripMemberHandler } from '../../../controllers/member.controller.ts';
+import prisma from '../../../config/prismaClient.ts';
+import { Request, Response } from 'express';
+
+jest.mock('../../../config/prismaClient', () => ({
+  __esModule: true,
+  default: {
+    tripMember: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+describe('Trip Member API - Update Role', () => {
+  let mockReq: Partial<Request>;
+  let mockRes: Partial<Response>;
+  let statusMock: jest.Mock;
+  let jsonMock: jest.Mock;
+
+  beforeEach(() => {
+    jsonMock = jest.fn();
+    statusMock = jest.fn().mockReturnValue({ json: jsonMock });
+
+    mockRes = {
+      status: statusMock,
+      json: jsonMock,
+    } as Partial<Response>;
+  });
+
+  const setupRequest = (overrides = {}) => ({
+    userId: 'creator-id',
+    params: { tripId: '1', userId: 'member-id' },
+    body: { role: 'admin' },
+    ...overrides,
+  });
+
+  it('should return 401 if user is not authenticated', async () => {
+    mockReq = setupRequest({ userId: undefined });
+
+    await updateTripMemberHandler(mockReq as Request, mockRes as Response);
+
+    expect(statusMock).toHaveBeenCalledWith(401);
+    expect(jsonMock).toHaveBeenCalledWith({ error: 'Unauthorized Request' });
+  });
+
+  it('should return 400 if tripId is invalid', async () => {
+    mockReq = setupRequest({
+      params: { tripId: 'invalid', userId: 'member-id' },
+    });
+
+    await updateTripMemberHandler(mockReq as Request, mockRes as Response);
+
+    expect(statusMock).toHaveBeenCalledWith(400);
+    expect(jsonMock).toHaveBeenCalledWith({ error: 'Invalid trip ID' });
+  });
+
+  it.each([
+    { role: undefined, expectedMessage: 'Invalid role update request' },
+    { role: 'superadmin', expectedMessage: 'Invalid role update request' },
+  ])(
+    'should return 400 if role is missing or invalid',
+    async ({ role, expectedMessage }) => {
+      mockReq = setupRequest({ body: { role } });
+
+      await updateTripMemberHandler(mockReq as Request, mockRes as Response);
+
+      expect(statusMock).toHaveBeenCalledWith(400);
+      expect(jsonMock).toHaveBeenCalledWith({ error: expectedMessage });
+    },
+  );
+
+  // ✅ NEW TEST CASE: Should return 403 if requester is not a member of the trip
+  it('should return 403 if requester is not a member of the trip', async () => {
+    mockReq = setupRequest();
+
+    (prisma.tripMember.findUnique as jest.Mock).mockResolvedValue(null);
+
+    await updateTripMemberHandler(mockReq as Request, mockRes as Response);
+
+    expect(statusMock).toHaveBeenCalledWith(403);
+    expect(jsonMock).toHaveBeenCalledWith({
+      error: 'You are not a member of this trip',
+    });
+  });
+
+  it('should update a member role successfully as a creator', async () => {
+    mockReq = setupRequest();
+
+    (prisma.tripMember.findUnique as jest.Mock)
+      .mockResolvedValueOnce({
+        userId: 'creator-id',
+        tripId: 1,
+        role: 'creator',
+      })
+      .mockResolvedValueOnce({
+        userId: 'member-id',
+        tripId: 1,
+        role: 'member',
+      });
+
+    (prisma.tripMember.update as jest.Mock).mockResolvedValue({
+      userId: 'member-id',
+      tripId: 1,
+      role: 'admin',
+    });
+
+    await updateTripMemberHandler(mockReq as Request, mockRes as Response);
+
+    expect(statusMock).toHaveBeenCalledWith(200);
+    expect(jsonMock).toHaveBeenCalledWith({
+      message: 'Member role updated successfully',
+      member: { userId: 'member-id', tripId: 1, role: 'admin' },
+    });
+  });
+
+  it('should return 500 on a database error', async () => {
+    mockReq = setupRequest();
+
+    (prisma.tripMember.findUnique as jest.Mock).mockRejectedValue(
+      new Error('Database failure'),
+    );
+
+    await updateTripMemberHandler(mockReq as Request, mockRes as Response);
+
+    expect(statusMock).toHaveBeenCalledWith(500);
+    expect(jsonMock).toHaveBeenCalledWith({
+      error: 'An unexpected database error occurred.',
+    });
+  });
+});

--- a/server/src/tests/unit/member.tests/member.validators.test.ts
+++ b/server/src/tests/unit/member.tests/member.validators.test.ts
@@ -1,0 +1,118 @@
+import { validateUpdateTripMemberInput } from '../../../middleware/member.validators.ts';
+import { validationResult } from 'express-validator';
+import { Request, Response } from 'express';
+
+describe('TripMember Validators Middleware', () => {
+  let mockReq: Partial<Request>;
+  let mockRes: Partial<Response>;
+  let next: jest.Mock;
+
+  beforeEach(() => {
+    mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    next = jest.fn();
+  });
+
+  const runValidation = async (req: Partial<Request>, validation: any) => {
+    await validation.run(req);
+    return validationResult(req);
+  };
+
+  describe('validateUpdateTripMemberRole', () => {
+    it('should pass validation for a valid request', async () => {
+      mockReq = {
+        params: { tripId: '1', userId: 'user-id' },
+        body: { role: 'admin' },
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateUpdateTripMemberInput,
+      );
+
+      expect(result.isEmpty()).toBe(true);
+    });
+
+    it('should fail validation if tripId is not a number', async () => {
+      mockReq = {
+        params: { tripId: 'abc', userId: 'user-id' },
+        body: { role: 'admin' },
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateUpdateTripMemberInput,
+      );
+
+      expect(result.isEmpty()).toBe(false);
+      expect(result.array()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ msg: 'Trip ID must be a positive number' }),
+        ]),
+      );
+    });
+
+    it('should fail validation if userId is missing', async () => {
+      mockReq = {
+        params: { tripId: '1' },
+        body: { role: 'admin' },
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateUpdateTripMemberInput,
+      );
+
+      expect(result.isEmpty()).toBe(false);
+      expect(result.array()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ msg: "Member's userId is required" }),
+        ]),
+      );
+    });
+
+    it('should fail validation if role is missing', async () => {
+      mockReq = {
+        params: { tripId: '1', userId: 'user-id' },
+        body: {},
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateUpdateTripMemberInput,
+      );
+
+      expect(result.isEmpty()).toBe(false);
+      expect(result.array()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            msg: 'Role must be either "admin" or "member"',
+          }),
+        ]),
+      );
+    });
+
+    it('should fail validation if role is not a valid option', async () => {
+      mockReq = {
+        params: { tripId: '1', userId: 'user-id' },
+        body: { role: 'invalid-role' },
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateUpdateTripMemberInput,
+      );
+
+      expect(result.isEmpty()).toBe(false);
+      expect(result.array()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            msg: 'Role must be either "admin" or "member"',
+          }),
+        ]),
+      );
+    });
+  });
+});


### PR DESCRIPTION
* There can only be one creator per trip.
* Creators can update everyone's roles (admins and members).
* Admins can only update members' roles
* Members have no power