### PR TITLE
229 account management and update password page

### DIFF
--- a/frontend/app/account/page.tsx
+++ b/frontend/app/account/page.tsx
@@ -21,6 +21,8 @@ export default function AccountPage() {
   const [isEditing, setIsEditing] = useState(false);
   const [newDisplayName, setNewDisplayName] = useState("");
   const [newEmail, setNewEmail] = useState("");
+  const [originalDisplayName, setOriginalDisplayName] = useState("");
+  const [originalEmail, setOriginalEmail] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -29,11 +31,23 @@ export default function AccountPage() {
   }, [user, fetchUser]);
 
   useEffect(() => {
-    setNewDisplayName(user?.user_metadata?.display_name || "");
-    setNewEmail(user?.email || "");
+    if (user) {
+      const displayName = user?.user_metadata?.display_name || "";
+      const email = user?.email || "";
+
+      setNewDisplayName(displayName);
+      setNewEmail(email);
+      setOriginalDisplayName(displayName);
+      setOriginalEmail(email);
+    }
   }, [user]);
 
   const handleSave = async () => {
+    if (newDisplayName === originalDisplayName && newEmail === originalEmail) {
+      setIsEditing(false);
+      return;
+    }
+
     setLoading(true);
     setError(null);
     try {
@@ -47,6 +61,8 @@ export default function AccountPage() {
         setNotification(error.message, "error");
       } else {
         await fetchUser();
+        setOriginalDisplayName(newDisplayName);
+        setOriginalEmail(newEmail);
         setIsEditing(false);
         setNotification("Profile updated successfully!", "success");
       }
@@ -57,6 +73,18 @@ export default function AccountPage() {
     } finally {
       setLoading(false);
     }
+  };
+
+  const handleCancel = () => {
+    setNewDisplayName(originalDisplayName);
+    setNewEmail(originalEmail);
+    setIsEditing(false);
+  };
+
+  const handleEdit = () => {
+    setNewDisplayName(originalDisplayName);
+    setNewEmail(originalEmail);
+    setIsEditing(true);
   };
 
   const handlePasswordReset = async () => {
@@ -165,20 +193,38 @@ export default function AccountPage() {
             )}
           </Box>
 
-          <Button
-            variant="contained"
-            onClick={isEditing ? handleSave : () => setIsEditing(true)}
-            disabled={loading}
-            sx={{ py: 1.5 }}
-          >
-            {loading ? (
-              <CircularProgress size={24} sx={{ color: "white" }} />
-            ) : isEditing ? (
-              "Save Changes"
-            ) : (
-              "Edit Profile"
-            )}
-          </Button>
+          {isEditing ? (
+            <Stack direction="row" spacing={2}>
+              <Button
+                variant="contained"
+                onClick={handleSave}
+                disabled={
+                  loading ||
+                  (newDisplayName === originalDisplayName &&
+                    newEmail === originalEmail)
+                }
+                sx={{ flex: 1 }}
+              >
+                {loading ? (
+                  <CircularProgress size={24} sx={{ color: "white" }} />
+                ) : (
+                  "Save Changes"
+                )}
+              </Button>
+              <Button
+                variant="outlined"
+                onClick={handleCancel}
+                disabled={loading}
+                sx={{ flex: 1 }}
+              >
+                Cancel
+              </Button>
+            </Stack>
+          ) : (
+            <Button variant="contained" onClick={handleEdit} sx={{ py: 1.5 }}>
+              Edit Profile
+            </Button>
+          )}
 
           <Box>
             <Typography variant="body2" color="textSecondary" gutterBottom>

--- a/frontend/app/account/page.tsx
+++ b/frontend/app/account/page.tsx
@@ -151,7 +151,7 @@ export default function AccountPage() {
           )}
 
           <Box>
-            <Typography variant="body2" color="textSecondary">
+            <Typography variant="body2" color="textSecondary" sx={{ mb: 1 }}>
               Display Name
             </Typography>
             {isEditing ? (
@@ -166,14 +166,14 @@ export default function AccountPage() {
                 }}
               />
             ) : (
-              <Typography variant="body1">
+              <Typography variant="h5">
                 {user?.user_metadata?.display_name || "N/A"}
               </Typography>
             )}
           </Box>
 
           <Box>
-            <Typography variant="body2" color="textSecondary">
+            <Typography variant="body2" color="textSecondary" sx={{ mb: 1 }}>
               Email
             </Typography>
             {isEditing ? (
@@ -189,7 +189,7 @@ export default function AccountPage() {
                 }}
               />
             ) : (
-              <Typography variant="body1">{user?.email || "N/A"}</Typography>
+              <Typography variant="h5">{user?.email || "N/A"}</Typography>
             )}
           </Box>
 

--- a/frontend/app/account/page.tsx
+++ b/frontend/app/account/page.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Container,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Email, Person } from "@mui/icons-material";
+import { supabase } from "@/utils/supabase/client";
+import { useUserStore } from "@/stores/user-store";
+import { useNotificationStore } from "@/stores/notification-store";
+
+export default function AccountPage() {
+  const { user, fetchUser } = useUserStore();
+  const { setNotification } = useNotificationStore();
+  const [isEditing, setIsEditing] = useState(false);
+  const [newDisplayName, setNewDisplayName] = useState("");
+  const [newEmail, setNewEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!user) fetchUser();
+  }, [user, fetchUser]);
+
+  useEffect(() => {
+    setNewDisplayName(user?.user_metadata?.display_name || "");
+    setNewEmail(user?.email || "");
+  }, [user]);
+
+  const handleSave = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const updates = {
+        email: newEmail,
+        data: { display_name: newDisplayName },
+      };
+
+      const { error } = await supabase.auth.updateUser(updates);
+      if (error) {
+        setNotification(error.message, "error");
+      } else {
+        await fetchUser();
+        setIsEditing(false);
+        setNotification("Profile updated successfully!", "success");
+      }
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setNotification(err.message, "error");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handlePasswordReset = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      if (!user?.email) {
+        setNotification("No email found for user", "error");
+        return;
+      }
+
+      const { error } = await supabase.auth.resetPasswordForEmail(user.email, {
+        redirectTo: `${window.location.origin}/update-password`,
+      });
+
+      if (error) {
+        setNotification(error.message, "error");
+      } else {
+        setNotification(
+          "Password reset email sent. Check your inbox.",
+          "success"
+        );
+      }
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Container
+      maxWidth="sm"
+      sx={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <Box
+        sx={{
+          p: 4,
+          bgcolor: "background.paper",
+          borderRadius: 3,
+          boxShadow: (theme) =>
+            theme.palette.mode === "dark"
+              ? "0 4px 20px rgba(255, 255, 255, 0.3)"
+              : "0 4px 20px rgba(0, 0, 0, 0.3)",
+          width: "100%",
+        }}
+      >
+        <Stack spacing={3}>
+          <Typography variant="h4" textAlign="center">
+            Account Settings
+          </Typography>
+
+          {error && (
+            <Typography color="error" textAlign="center">
+              {error}
+            </Typography>
+          )}
+
+          <Box>
+            <Typography variant="body2" color="textSecondary">
+              Display Name
+            </Typography>
+            {isEditing ? (
+              <TextField
+                fullWidth
+                value={newDisplayName}
+                onChange={(e) => setNewDisplayName(e.target.value)}
+                InputProps={{
+                  startAdornment: (
+                    <Person sx={{ mr: 1, color: "secondary.main" }} />
+                  ),
+                }}
+              />
+            ) : (
+              <Typography variant="body1">
+                {user?.user_metadata?.display_name || "N/A"}
+              </Typography>
+            )}
+          </Box>
+
+          <Box>
+            <Typography variant="body2" color="textSecondary">
+              Email
+            </Typography>
+            {isEditing ? (
+              <TextField
+                fullWidth
+                type="email"
+                value={newEmail}
+                onChange={(e) => setNewEmail(e.target.value)}
+                InputProps={{
+                  startAdornment: (
+                    <Email sx={{ mr: 1, color: "secondary.main" }} />
+                  ),
+                }}
+              />
+            ) : (
+              <Typography variant="body1">{user?.email || "N/A"}</Typography>
+            )}
+          </Box>
+
+          <Button
+            variant="contained"
+            onClick={isEditing ? handleSave : () => setIsEditing(true)}
+            disabled={loading}
+            sx={{ py: 1.5 }}
+          >
+            {loading ? (
+              <CircularProgress size={24} sx={{ color: "white" }} />
+            ) : isEditing ? (
+              "Save Changes"
+            ) : (
+              "Edit Profile"
+            )}
+          </Button>
+
+          <Box>
+            <Typography variant="body2" color="textSecondary" gutterBottom>
+              Password
+            </Typography>
+            <Button
+              variant="outlined"
+              onClick={handlePasswordReset}
+              disabled={loading}
+              fullWidth
+            >
+              Send Password Reset Email
+            </Button>
+          </Box>
+        </Stack>
+      </Box>
+    </Container>
+  );
+}

--- a/frontend/app/account/page.tsx
+++ b/frontend/app/account/page.tsx
@@ -9,13 +9,17 @@ import {
   Stack,
   TextField,
   Typography,
+  Avatar,
+  Divider,
 } from "@mui/material";
-import { Email, Person } from "@mui/icons-material";
+import { Email, Person, LockReset, Edit, ArrowBack } from "@mui/icons-material";
 import { supabase } from "@/utils/supabase/client";
 import { useUserStore } from "@/stores/user-store";
 import { useNotificationStore } from "@/stores/notification-store";
+import { useRouter } from "next/navigation";
 
 export default function AccountPage() {
+  const router = useRouter();
   const { user, fetchUser } = useUserStore();
   const { setNotification } = useNotificationStore();
   const [isEditing, setIsEditing] = useState(false);
@@ -117,6 +121,15 @@ export default function AccountPage() {
     }
   };
 
+  const getInitials = (name: string) => {
+    if (!name) return "??";
+    const names = name.split(" ");
+    return names
+      .map((n) => n[0])
+      .join("")
+      .toUpperCase();
+  };
+
   return (
     <Container
       maxWidth="sm"
@@ -137,108 +150,181 @@ export default function AccountPage() {
               ? "0 4px 20px rgba(255, 255, 255, 0.3)"
               : "0 4px 20px rgba(0, 0, 0, 0.3)",
           width: "100%",
+          transform: "translateY(-5%)",
+          position: "relative",
+          overflow: "hidden",
+          "&:before": {
+            content: '""',
+            position: "absolute",
+            top: -50,
+            right: -50,
+            width: 100,
+            height: 100,
+            bgcolor: "primary.main",
+            borderRadius: "50%",
+            opacity: 0.4,
+          },
+          "&:after": {
+            content: '""',
+            position: "absolute",
+            bottom: -80,
+            left: -30,
+            width: 150,
+            height: 150,
+            bgcolor: "secondary.main",
+            borderRadius: "50%",
+            opacity: 0.4,
+          },
         }}
       >
+        <Button
+          startIcon={<ArrowBack />}
+          onClick={() => router.push("/dashboard")}
+          sx={{
+            position: "absolute",
+            top: 16,
+            left: 16,
+            color: "text.secondary",
+            "&:hover": {
+              color: "primary.main",
+              bgcolor: "action.hover",
+            },
+          }}
+        >
+          Dashboard
+        </Button>
         <Stack spacing={3}>
-          <Typography variant="h4" textAlign="center">
-            Account Settings
-          </Typography>
+          <Stack alignItems="center" spacing={2}>
+            <Avatar
+              sx={{
+                width: 80,
+                height: 80,
+                bgcolor: "primary.main",
+                fontSize: "2rem",
+                mb: 2,
+                boxShadow: 3,
+              }}
+            >
+              {getInitials(user?.user_metadata?.display_name || "")}
+            </Avatar>
+            <Typography variant="h4" textAlign="center" fontWeight="bold">
+              Account Settings
+            </Typography>
+            <Divider sx={{ width: "60%", my: 2 }} />
+          </Stack>
 
           {error && (
-            <Typography color="error" textAlign="center">
+            <Typography color="error" textAlign="center" variant="body2">
               {error}
             </Typography>
           )}
 
-          <Box>
-            <Typography variant="body2" color="textSecondary" sx={{ mb: 1 }}>
-              Display Name
-            </Typography>
-            {isEditing ? (
-              <TextField
-                fullWidth
-                value={newDisplayName}
-                onChange={(e) => setNewDisplayName(e.target.value)}
-                InputProps={{
-                  startAdornment: (
-                    <Person sx={{ mr: 1, color: "secondary.main" }} />
-                  ),
-                }}
-              />
-            ) : (
-              <Typography variant="h5">
-                {user?.user_metadata?.display_name || "N/A"}
+          <Box
+            sx={{
+              p: 3,
+              borderRadius: 2,
+              bgcolor: "action.hover",
+              position: "relative",
+            }}
+          >
+            <Box>
+              <Typography variant="body2" color="textSecondary" gutterBottom>
+                <Person sx={{ verticalAlign: "middle", mr: 1 }} />
+                Display Name
               </Typography>
-            )}
+              {isEditing ? (
+                <TextField
+                  fullWidth
+                  value={newDisplayName}
+                  onChange={(e) => setNewDisplayName(e.target.value)}
+                  variant="outlined"
+                  size="small"
+                />
+              ) : (
+                <Typography variant="body1" sx={{ ml: 1.5 }}>
+                  {user?.user_metadata?.display_name || "N/A"}
+                </Typography>
+              )}
+            </Box>
+
+            <Box sx={{ mt: 3 }}>
+              <Typography variant="body2" color="textSecondary" gutterBottom>
+                <Email sx={{ verticalAlign: "middle", mr: 1 }} />
+                Email Address
+              </Typography>
+              {isEditing ? (
+                <TextField
+                  fullWidth
+                  type="email"
+                  value={newEmail}
+                  onChange={(e) => setNewEmail(e.target.value)}
+                  variant="outlined"
+                  size="small"
+                />
+              ) : (
+                <Typography variant="body1" sx={{ ml: 1.5 }}>
+                  {user?.email || "N/A"}
+                </Typography>
+              )}
+            </Box>
           </Box>
 
-          <Box>
-            <Typography variant="body2" color="textSecondary" sx={{ mb: 1 }}>
-              Email
-            </Typography>
+          <Stack spacing={2} sx={{ mt: 3 }}>
             {isEditing ? (
-              <TextField
-                fullWidth
-                type="email"
-                value={newEmail}
-                onChange={(e) => setNewEmail(e.target.value)}
-                InputProps={{
-                  startAdornment: (
-                    <Email sx={{ mr: 1, color: "secondary.main" }} />
-                  ),
-                }}
-              />
+              <Stack direction="row" spacing={2}>
+                <Button
+                  variant="contained"
+                  onClick={handleSave}
+                  disabled={
+                    loading ||
+                    (newDisplayName === originalDisplayName &&
+                      newEmail === originalEmail)
+                  }
+                  sx={{ flex: 1, py: 1.5 }}
+                  startIcon={
+                    loading ? (
+                      <CircularProgress size={20} sx={{ color: "white" }} />
+                    ) : (
+                      <Person />
+                    )
+                  }
+                >
+                  Save Changes
+                </Button>
+                <Button
+                  variant="outlined"
+                  onClick={handleCancel}
+                  disabled={loading}
+                  sx={{ flex: 1, py: 1.5 }}
+                >
+                  Cancel
+                </Button>
+              </Stack>
             ) : (
-              <Typography variant="h5">{user?.email || "N/A"}</Typography>
-            )}
-          </Box>
-
-          {isEditing ? (
-            <Stack direction="row" spacing={2}>
               <Button
                 variant="contained"
-                onClick={handleSave}
-                disabled={
-                  loading ||
-                  (newDisplayName === originalDisplayName &&
-                    newEmail === originalEmail)
-                }
-                sx={{ flex: 1 }}
+                onClick={handleEdit}
+                sx={{ py: 1.5 }}
+                startIcon={<Edit />}
               >
-                {loading ? (
-                  <CircularProgress size={24} sx={{ color: "white" }} />
-                ) : (
-                  "Save Changes"
-                )}
+                Edit Profile
               </Button>
-              <Button
-                variant="outlined"
-                onClick={handleCancel}
-                disabled={loading}
-                sx={{ flex: 1 }}
-              >
-                Cancel
-              </Button>
-            </Stack>
-          ) : (
-            <Button variant="contained" onClick={handleEdit} sx={{ py: 1.5 }}>
-              Edit Profile
-            </Button>
-          )}
+            )}
 
-          <Box>
-            <Typography variant="body2" color="textSecondary" gutterBottom>
-              Password
-            </Typography>
+            <Divider sx={{ my: 2 }} />
+
             <Button
               variant="outlined"
               onClick={handlePasswordReset}
               disabled={loading}
               fullWidth
+              sx={{ py: 1.5 }}
+              startIcon={<LockReset />}
+              color="secondary"
             >
               Send Password Reset Email
             </Button>
-          </Box>
+          </Stack>
         </Stack>
       </Box>
     </Container>

--- a/frontend/app/login/AuthForm.tsx
+++ b/frontend/app/login/AuthForm.tsx
@@ -22,6 +22,7 @@ import {
   Visibility,
   VisibilityOff,
   Person,
+  LockReset,
 } from "@mui/icons-material";
 import { getMessages } from "./messages";
 import { useUserStore } from "@/stores/user-store";
@@ -34,6 +35,7 @@ export default function AuthForm() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
+  const [resetLoading, setResetLoading] = useState(false);
   const [formLoading, setFormLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [formType, setFormType] = useState<"login" | "signup">("login");
@@ -111,6 +113,33 @@ export default function AuthForm() {
       }
     } finally {
       setFormLoading(false);
+    }
+  };
+
+  const handlePasswordReset = async () => {
+    setResetLoading(true);
+    setError(null);
+    try {
+      if (!email.trim()) {
+        throw new Error("Please enter your email address");
+      }
+
+      const { error } = await supabase.auth.resetPasswordForEmail(email, {
+        redirectTo: `${window.location.origin}/update-password`,
+      });
+
+      if (error) throw error;
+
+      setNotification(
+        "Password reset email sent. Check your inbox.",
+        "success"
+      );
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message);
+      }
+    } finally {
+      setResetLoading(false);
     }
   };
 
@@ -222,6 +251,29 @@ export default function AuthForm() {
               ),
             }}
           />
+
+          {formType === "login" && (
+            <Box sx={{ textAlign: "right", mt: -1 }}>
+              <Button
+                variant="text"
+                onClick={handlePasswordReset}
+                disabled={resetLoading}
+                startIcon={
+                  resetLoading ? <CircularProgress size={16} /> : <LockReset />
+                }
+                sx={{
+                  color: "text.secondary",
+                  fontSize: "0.8rem",
+                  "&:hover": {
+                    color: "primary.main",
+                    bgcolor: "transparent",
+                  },
+                }}
+              >
+                Forgot Password?
+              </Button>
+            </Box>
+          )}
 
           {formType === "signup" && (
             <TextField

--- a/frontend/app/login/AuthForm.tsx
+++ b/frontend/app/login/AuthForm.tsx
@@ -21,6 +21,7 @@ import {
   Email,
   Visibility,
   VisibilityOff,
+  Person,
 } from "@mui/icons-material";
 import { getMessages } from "./messages";
 import { useUserStore } from "@/stores/user-store";
@@ -29,6 +30,7 @@ import { useNotificationStore } from "@/stores/notification-store";
 export default function AuthForm() {
   const { setNotification } = useNotificationStore();
   const { fetchUser } = useUserStore();
+  const [displayName, setDisplayName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -64,9 +66,21 @@ export default function AuthForm() {
         });
         if (error) throw error;
       } else {
+        if (!displayName.trim()) {
+          throw new Error(getMessages.displayNameError);
+        }
+        if (!email.trim()) throw new Error(getMessages.emailError);
         if (password !== confirmPassword)
           throw new Error(getMessages.passwordsUnmatchError);
-        const { error } = await supabase.auth.signUp({ email, password });
+
+        const { error } = await supabase.auth.signUp({
+          email,
+          password,
+          options: {
+            data: { display_name: displayName },
+          },
+        });
+
         if (error) throw error;
       }
       // immediately feteh user so we keep the store updated
@@ -159,6 +173,22 @@ export default function AuthForm() {
           noValidate
           sx={{ display: "flex", flexDirection: "column", gap: 2 }}
         >
+          {formType === "signup" && (
+            <TextField
+              label="Display Name"
+              type="text"
+              fullWidth
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              required
+              InputProps={{
+                startAdornment: (
+                  <Person sx={{ mr: 1, color: "secondary.main" }} />
+                ),
+              }}
+            />
+          )}
+
           <TextField
             label="Email"
             type="email"

--- a/frontend/app/login/messages.ts
+++ b/frontend/app/login/messages.ts
@@ -15,4 +15,6 @@ export const getMessages = {
   passwordsUnmatchError: "Passwords don't match.",
   dontHaveAccount: "Don't have an account?",
   haveAnAccount: "Already have an account?",
+  emailError: "Valid Email is required.",
+  displayNameError: "Display Name is required.",
 };

--- a/frontend/app/update-password/page.tsx
+++ b/frontend/app/update-password/page.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { supabase } from "@/utils/supabase/client";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Container,
+  Stack,
+  TextField,
+  Typography,
+  InputAdornment,
+  IconButton,
+} from "@mui/material";
+import { Lock, Visibility, VisibilityOff } from "@mui/icons-material";
+import { useNotificationStore } from "@/stores/notification-store";
+import { useUserStore } from "@/stores/user-store";
+
+export default function UpdatePasswordPage() {
+  const router = useRouter();
+  const { setNotification } = useNotificationStore();
+  const { fetchUser } = useUserStore();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
+  // this route can't be protected, we will check for valid session from redirect url and proceed accordingly
+  useEffect(() => {
+    const checkRecoverySession = async () => {
+      try {
+        const {
+          data: { session },
+        } = await supabase.auth.getSession();
+
+        if (session) {
+          setLoading(false);
+        } else {
+          setNotification("Invalid or expired password reset link", "error");
+          router.push("/login");
+        }
+      } catch (err) {
+        console.error("Session check error: ", err);
+        setNotification("Error validating reset link", "error");
+        router.push("/account");
+      }
+    };
+
+    checkRecoverySession();
+  }, [router, setNotification]);
+
+  const handlePasswordReset = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    try {
+      if (password !== confirmPassword) {
+        throw new Error("Passwords do not match");
+      }
+      if (password.length < 8) {
+        throw new Error("Password must be at least 8 characters");
+      }
+
+      const { error } = await supabase.auth.updateUser({
+        password,
+      });
+
+      if (error) throw error;
+
+      await fetchUser();
+
+      // redirect to account page since thats where they initially came from
+      setNotification("Password updated successfully!", "success");
+      router.push("/account");
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message);
+        setNotification(err.message, "error");
+      }
+    }
+  };
+
+  if (loading) {
+    return (
+      <Container
+        maxWidth="sm"
+        sx={{
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <Box display="flex" justifyContent="center" p={4}>
+          <CircularProgress size={60} />
+        </Box>
+      </Container>
+    );
+  }
+
+  return (
+    <Container
+      maxWidth="sm"
+      sx={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <Box
+        sx={{
+          p: 4,
+          bgcolor: "background.paper",
+          borderRadius: 3,
+          boxShadow: (theme) =>
+            theme.palette.mode === "dark"
+              ? "0 4px 20px rgba(255, 255, 255, 0.3)"
+              : "0 4px 20px rgba(0, 0, 0, 0.3)",
+          width: "100%",
+        }}
+      >
+        <Stack component="form" spacing={3} onSubmit={handlePasswordReset}>
+          <Typography variant="h4" textAlign="center" gutterBottom>
+            Reset Password
+          </Typography>
+
+          {error && (
+            <Typography color="error" textAlign="center">
+              {error}
+            </Typography>
+          )}
+
+          <TextField
+            label="New Password"
+            type={showPassword ? "text" : "password"}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            fullWidth
+            InputProps={{
+              startAdornment: <Lock sx={{ mr: 1, color: "secondary.main" }} />,
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton
+                    onClick={() => setShowPassword(!showPassword)}
+                    edge="end"
+                  >
+                    {showPassword ? <VisibilityOff /> : <Visibility />}
+                  </IconButton>
+                </InputAdornment>
+              ),
+            }}
+          />
+
+          <TextField
+            label="Confirm Password"
+            type={showConfirmPassword ? "text" : "password"}
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            required
+            fullWidth
+            InputProps={{
+              startAdornment: <Lock sx={{ mr: 1, color: "secondary.main" }} />,
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton
+                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                    edge="end"
+                  >
+                    {showConfirmPassword ? <VisibilityOff /> : <Visibility />}
+                  </IconButton>
+                </InputAdornment>
+              ),
+            }}
+          />
+
+          <Button
+            type="submit"
+            variant="contained"
+            fullWidth
+            sx={{
+              py: 1.5,
+              bgcolor: "primary.main",
+              "&:hover": { bgcolor: "primary.dark" },
+            }}
+          >
+            Update Password
+          </Button>
+
+          <Button
+            variant="outlined"
+            onClick={() => router.push("/account")}
+            fullWidth
+            sx={{
+              borderColor: "secondary.main",
+              color: "secondary.main",
+              "&:hover": { borderColor: "primary.main", color: "primary.main" },
+            }}
+          >
+            Back to Account
+          </Button>
+        </Stack>
+      </Box>
+    </Container>
+  );
+}

--- a/frontend/components/navbar/Navbar.tsx
+++ b/frontend/components/navbar/Navbar.tsx
@@ -11,8 +11,9 @@ import {
   IconButton,
   ListItemIcon,
   CircularProgress,
+  Avatar,
 } from "@mui/material";
-import { LogoutTwoTone } from "@mui/icons-material";
+import { DashboardTwoTone, LogoutTwoTone } from "@mui/icons-material";
 import ThemeToggle from "../ThemeToggle";
 import { useEffect, useState } from "react";
 import { supabase } from "@/utils/supabase/client";
@@ -68,6 +69,10 @@ export default function Navbar() {
     router.replace("/login");
   };
 
+  const displayName =
+    user?.user_metadata?.display_name || user?.email || "User";
+  const avatarLetter = displayName.charAt(0).toUpperCase();
+
   return (
     <AppBar position="fixed" sx={{ bgcolor: "primary.main" }}>
       <Toolbar className="flex justify-between items-center px-4">
@@ -109,14 +114,50 @@ export default function Navbar() {
                   "& .MuiPaper-root": {
                     borderRadius: "8px",
                     boxShadow: "0px 4px 10px rgba(0,0,0,0.2)",
+                    minWidth: "180px",
+                    padding: "8px 0",
                   },
                 }}
               >
-                {user && (
-                  <MenuItem onClick={handleMenuClose}>
-                    <Link href="/dashboard">Dashboard</Link>
-                  </MenuItem>
-                )}
+                <MenuItem
+                  onClick={() => {
+                    router.push("/account");
+                    handleMenuClose();
+                  }}
+                  sx={{
+                    padding: "12px 16px",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "12px",
+                  }}
+                >
+                  <Avatar
+                    sx={{
+                      bgcolor: "secondary.main",
+                      width: 36,
+                      height: 36,
+                      mr: 1,
+                    }}
+                  >
+                    {avatarLetter}
+                  </Avatar>
+                  <Box>
+                    <Typography variant="body1" fontWeight="bold">
+                      {displayName}
+                    </Typography>
+                    <Typography variant="caption" sx={{ color: "gray" }}>
+                      Manage Account
+                    </Typography>
+                  </Box>
+                </MenuItem>
+
+                <MenuItem onClick={handleMenuClose}>
+                  <ListItemIcon>
+                    <DashboardTwoTone />
+                  </ListItemIcon>
+                  <Link href="/dashboard">Dashboard</Link>
+                </MenuItem>
+
                 <MenuItem onClick={handleLogout} disabled={loading}>
                   <ListItemIcon>
                     {loading ? (

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -9,7 +9,7 @@ export async function middleware(request: NextRequest) {
     data: { session },
   } = await supabase.auth.getSession();
   // add all the routes here that needs to be protected, we won't need to individually check in any route user's authentication
-  const protectedRoutes = ["/dashboard", "/trips"];
+  const protectedRoutes = ["/dashboard", "/trips", "/account"];
 
   const isProtectedRoute = protectedRoutes.some((route) =>
     request.nextUrl.pathname.startsWith(route)
@@ -23,5 +23,5 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/dashboard/:path*", "/trips/:path*"],
+  matcher: ["/dashboard/:path*", "/trips/:path*", "/account"],
 };


### PR DESCRIPTION
Added a field for Display Name in Sign up form - even if they give only first name, its fine
Created `/account` page for user info management - actions they can do - update name, email, reset password
Created `/update-password` - takes the new password input and changes the password
Added `Forgot Password` in login/signup page
Added `User account management` in the hamburger menu

Everything is self explanatory but for update password please see the flow below -

On clicking get link to reset password, user gets an email. They open the supabase link, it will redirect to our /update-password page. On success of password update, they will be redirected to the /account page. Since redirect is to /account in the end, added a back to dashboard button on the card for quick navigation.

All the errors, successes for everything should show up as a snackbar - used our notification store for that
