### PR TITLE
346 implement api endpoints for map and location

### DIFF
--- a/frontend/components/chat/Chat.tsx
+++ b/frontend/components/chat/Chat.tsx
@@ -850,14 +850,13 @@ export default function Chat() {
                                   : "grey.600",
                             }}
                           >
-                            {getUserFullName(msg.userId)} •{" "}
+                            {getUserFullName(msg.userId)}•{" "}
                             {formatTimestamp(msg.createdAt)}
                           </Typography>
                           <Box
                             sx={{
                               maxWidth: "70%",
                               wordWrap: "break-word",
-                              overflowWrap: "break-word",
                               whiteSpace: "normal",
                               overflow: "hidden",
                               backgroundColor:

--- a/frontend/components/chat/Chat.tsx
+++ b/frontend/components/chat/Chat.tsx
@@ -856,6 +856,10 @@ export default function Chat() {
                           <Box
                             sx={{
                               maxWidth: "70%",
+                              wordWrap: "break-word",
+                              overflowWrap: "break-word",
+                              whiteSpace: "normal",
+                              overflow: "hidden",
                               backgroundColor:
                                 msg.userId === user.id
                                   ? "var(--primary-hover)"

--- a/server/src/controllers/markedLocation.controller.ts
+++ b/server/src/controllers/markedLocation.controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express';
 import { AuthenticatedRequest } from '@/interfaces/interfaces.js';
 import { handleControllerError } from '@/utils/errorHandlers.js';
-import { LocationType } from '@prisma/client';
+import { LocationType } from '@/interfaces/enums.js';
 import {
   createMarkedLocation,
   getAllMarkedLocationsForTrip,
@@ -140,7 +140,7 @@ export const updateMarkedLocationNotesHandler = async (
     }
 
     // Check if the location exists and belongs to the specified trip
-    const location = await getMarkedLocationById(tripId, locationId, userId);
+    const location = await getMarkedLocationById(tripId, locationId);
     if (!location) {
       res.status(404).json({ error: 'Marked location not found' });
       return;
@@ -199,8 +199,8 @@ export const deleteMarkedLocationHandler = async (
       return;
     }
 
-    // Check if the location exists first
-    const location = await getMarkedLocationById(tripId, locationId, userId);
+    // Check if the location exists and belongs to the specified trip
+    const location = await getMarkedLocationById(tripId, locationId);
     if (!location) {
       res.status(404).json({ error: 'Marked location not found' });
       return;
@@ -219,11 +219,7 @@ export const deleteMarkedLocationHandler = async (
     }
 
     // Delete the location
-    const deletedLocation = await deleteMarkedLocation(
-      tripId,
-      locationId,
-      userId,
-    );
+    const deletedLocation = await deleteMarkedLocation(locationId);
 
     res.status(200).json({
       message: 'Marked location deleted successfully',

--- a/server/src/controllers/markedLocation.controller.ts
+++ b/server/src/controllers/markedLocation.controller.ts
@@ -98,7 +98,7 @@ export const getAllMarkedLocationsHandler = async (
       return;
     }
 
-    const markedLocations = await getAllMarkedLocationsForTrip(tripId, userId);
+    const markedLocations = await getAllMarkedLocationsForTrip(tripId);
 
     res.status(200).json({
       message: 'Marked locations retrieved successfully',

--- a/server/src/controllers/markedLocation.controller.ts
+++ b/server/src/controllers/markedLocation.controller.ts
@@ -146,18 +146,6 @@ export const updateMarkedLocationNotesHandler = async (
       return;
     }
 
-    const isMarkerCreator = location.createdById === userId;
-    const isTripAdminOrCreator =
-      requestingMember.role === 'admin' || requestingMember.role === 'creator';
-
-    if (!isMarkerCreator && !isTripAdminOrCreator) {
-      res.status(403).json({
-        error:
-          'Only the marker creator, trip admins, and trip creators can update marked locations',
-      });
-      return;
-    }
-
     // Update the notes
     const updatedLocation = await updateMarkedLocationNotes(locationId, notes);
 

--- a/server/src/controllers/markedLocation.controller.ts
+++ b/server/src/controllers/markedLocation.controller.ts
@@ -130,7 +130,7 @@ export const updateMarkedLocationNotesHandler = async (
       return;
     }
 
-    // Check if the user is a member of the trip and get their role
+    // Check if the user is a member of the trip
     const requestingMember = await getTripMember(tripId, userId);
     if (!requestingMember) {
       res.status(403).json({

--- a/server/src/controllers/markedLocation.controller.ts
+++ b/server/src/controllers/markedLocation.controller.ts
@@ -1,0 +1,186 @@
+import { Request, Response } from 'express';
+import { AuthenticatedRequest } from '@/interfaces/interfaces.js';
+import { handleControllerError } from '@/utils/errorHandlers.js';
+import { LocationType } from '@prisma/client';
+import {
+  createMarkedLocation,
+  getAllMarkedLocationsForTrip,
+  updateMarkedLocationNotes,
+  deleteMarkedLocation,
+  getMarkedLocationById,
+} from '@/models/markedLocation.model.js';
+import { getTripMember } from '@/models/member.model.js';
+
+// Create a new marked location
+export const createMarkedLocationHandler = async (
+  req: Request,
+  res: Response,
+) => {
+  try {
+    const { userId } = req as AuthenticatedRequest;
+    const tripId = Number(req.params.tripId);
+    const { name, type, coordinates, address, notes, website, phoneNumber } =
+      req.body;
+
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized Request' });
+      return;
+    }
+
+    if (isNaN(tripId)) {
+      res.status(400).json({ error: 'Invalid trip ID' });
+      return;
+    }
+
+    // Check if the user is a member of the trip
+    const requestingMember = await getTripMember(tripId, userId);
+    if (!requestingMember) {
+      res.status(403).json({
+        error: `You are not a member of this trip: ${tripId}`,
+      });
+      return;
+    }
+
+    // Map type to LocationType enum
+    const locationTypeEnum = Object.values(LocationType).includes(
+      type?.toUpperCase(),
+    )
+      ? (type.toUpperCase() as LocationType)
+      : LocationType.OTHER;
+
+    // Create the marked location
+    const markedLocation = await createMarkedLocation({
+      tripId,
+      name,
+      type: locationTypeEnum,
+      coordinates,
+      address,
+      createdById: userId,
+      notes,
+      website,
+      phoneNumber,
+    });
+
+    res.status(201).json({
+      message: 'Marked location created successfully',
+      markedLocation,
+    });
+  } catch (error) {
+    handleControllerError(error, res, 'Error creating marked location:');
+  }
+};
+
+// Get all marked locations for a trip
+export const getAllMarkedLocationsHandler = async (
+  req: Request,
+  res: Response,
+) => {
+  try {
+    const { userId } = req as AuthenticatedRequest;
+    const tripId = Number(req.params.tripId);
+
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized Request' });
+      return;
+    }
+
+    if (isNaN(tripId)) {
+      res.status(400).json({ error: 'Invalid trip ID' });
+      return;
+    }
+
+    const markedLocations = await getAllMarkedLocationsForTrip(tripId, userId);
+
+    res.status(200).json({
+      message: 'Marked locations retrieved successfully',
+      markedLocations,
+    });
+  } catch (error) {
+    handleControllerError(error, res, 'Error retrieving marked locations:');
+  }
+};
+
+// Update the notes of a marked location
+export const updateMarkedLocationNotesHandler = async (
+  req: Request,
+  res: Response,
+) => {
+  try {
+    const { userId } = req as AuthenticatedRequest;
+    const tripId = Number(req.params.tripId);
+    const locationId = req.params.locationId;
+    const { notes } = req.body;
+
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized Request' });
+      return;
+    }
+
+    if (isNaN(tripId)) {
+      res.status(400).json({ error: 'Invalid trip ID' });
+      return;
+    }
+
+    // Check if the user is a member of the trip
+    const requestingMember = await getTripMember(tripId, userId);
+    if (!requestingMember) {
+      res.status(403).json({
+        error: `You are not a member of this trip: ${tripId}`,
+      });
+      return;
+    }
+
+    // Check if the location exists and belongs to the specified trip
+    const location = await getMarkedLocationById(tripId, locationId, userId);
+    if (!location) {
+      res.status(404).json({ error: 'Marked location not found' });
+      return;
+    }
+
+    // Update the notes
+    const updatedLocation = await updateMarkedLocationNotes(locationId, notes);
+
+    res.status(200).json({
+      message: 'Marked location notes updated successfully',
+      updatedLocation,
+    });
+  } catch (error) {
+    handleControllerError(error, res, 'Error updating marked location notes:');
+  }
+};
+
+// Delete a marked location
+export const deleteMarkedLocationHandler = async (
+  req: Request,
+  res: Response,
+) => {
+  try {
+    const { userId } = req as AuthenticatedRequest;
+    const tripId = Number(req.params.tripId);
+    const locationId = req.params.locationId;
+
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized Request' });
+      return;
+    }
+
+    if (isNaN(tripId)) {
+      res.status(400).json({ error: 'Invalid trip ID' });
+      return;
+    }
+
+    // Delete the location (permissions are checked in the model)
+    const deletedLocation = await deleteMarkedLocation(
+      tripId,
+      locationId,
+      userId,
+    );
+
+    res.status(200).json({
+      message: 'Marked location deleted successfully',
+      deletedLocation,
+    });
+  } catch (error) {
+    handleControllerError(error, res, 'Error deleting marked location:');
+  }
+};

--- a/server/src/interfaces/enums.ts
+++ b/server/src/interfaces/enums.ts
@@ -21,3 +21,12 @@ export enum EventCategory {
   FREE_TIME = 'FREE_TIME',
   OTHER = 'OTHER',
 }
+
+export enum LocationType {
+  ACCOMMODATION = 'ACCOMMODATION',
+  RESTAURANT = 'RESTAURANT',
+  CAFE = 'CAFE',
+  SHOPPING = 'SHOPPING',
+  GAS_STATION = 'GAS_STATION',
+  OTHER = 'OTHER',
+}

--- a/server/src/interfaces/interfaces.ts
+++ b/server/src/interfaces/interfaces.ts
@@ -1,6 +1,5 @@
 import { Request } from 'express';
-import { EventCategory } from './enums';
-import { LocationType } from '@prisma/client';
+import { EventCategory, LocationType } from './enums';
 
 export interface AuthenticatedRequest extends Request {
   userId: string;

--- a/server/src/interfaces/interfaces.ts
+++ b/server/src/interfaces/interfaces.ts
@@ -1,5 +1,6 @@
 import { Request } from 'express';
-import { EventCategory, LocationType } from './enums';
+import { EventCategory } from './enums';
+import { LocationType } from '@prisma/client';
 
 export interface AuthenticatedRequest extends Request {
   userId: string;

--- a/server/src/interfaces/interfaces.ts
+++ b/server/src/interfaces/interfaces.ts
@@ -1,5 +1,5 @@
 import { Request } from 'express';
-import { EventCategory } from './enums';
+import { EventCategory, LocationType } from './enums';
 
 export interface AuthenticatedRequest extends Request {
   userId: string;
@@ -95,4 +95,16 @@ export interface NotificationFilterOptions {
   isRead?: boolean;
   type?: string;
   limit?: number;
+}
+
+export interface CreateMarkedLocationInput {
+  tripId: number;
+  name: string;
+  type: LocationType;
+  coordinates: { latitude: number; longitude: number };
+  address?: string;
+  createdById: string;
+  notes?: string;
+  website?: string;
+  phoneNumber?: string;
 }

--- a/server/src/middleware/markedLocation.validators.ts
+++ b/server/src/middleware/markedLocation.validators.ts
@@ -1,0 +1,114 @@
+import { body, checkExact, param } from 'express-validator';
+import { LocationType } from '@prisma/client';
+
+// Helper function to check if a value is a valid enum value
+const isValidLocationType = (value: string) => {
+  return Object.values(LocationType).includes(value as LocationType);
+};
+
+// Validation for coordinates
+const validateCoordinates = (coordinates: any) => {
+  if (!coordinates || typeof coordinates !== 'object') {
+    throw new Error('Coordinates must be an object');
+  }
+
+  if (
+    !('latitude' in coordinates) ||
+    !('longitude' in coordinates) ||
+    typeof coordinates.latitude !== 'number' ||
+    typeof coordinates.longitude !== 'number'
+  ) {
+    throw new Error(
+      'Coordinates must include valid latitude and longitude numbers',
+    );
+  }
+
+  if (
+    coordinates.latitude < -90 ||
+    coordinates.latitude > 90 ||
+    coordinates.longitude < -180 ||
+    coordinates.longitude > 180
+  ) {
+    throw new Error('Latitude and longitude values are out of range');
+  }
+
+  return true;
+};
+
+// Validation for Creating a Marked Location
+export const validateCreateMarkedLocationInput = checkExact([
+  param('tripId').isInt({ min: 1 }).withMessage('Trip ID must be a number'),
+
+  body('name').isString().notEmpty().withMessage('Name is required'),
+
+  body('type')
+    .isString()
+    .notEmpty()
+    .withMessage('Type is required')
+    .custom((value) => {
+      if (!isValidLocationType(value)) {
+        throw new Error(
+          `Invalid type. Allowed values: ${Object.values(LocationType).join(
+            ', ',
+          )}`,
+        );
+      }
+      return true;
+    }),
+
+  body('coordinates')
+    .notEmpty()
+    .withMessage('Coordinates are required')
+    .custom(validateCoordinates),
+
+  body('address')
+    .optional({ values: 'null' })
+    .isString()
+    .withMessage('Address must be a string'),
+
+  body('notes')
+    .optional({ values: 'null' })
+    .isString()
+    .withMessage('Notes must be a string'),
+
+  body('website')
+    .optional({ values: 'null' })
+    .isString()
+    .isURL()
+    .withMessage('Website must be a valid URL'),
+
+  body('phoneNumber')
+    .optional({ values: 'null' })
+    .isString()
+    .withMessage('Phone number must be a string'),
+]);
+
+// Validation for Updating the Notes of a Marked Location
+export const validateUpdateMarkedLocationNotesInput = checkExact([
+  param('tripId').isInt({ min: 1 }).withMessage('Trip ID must be a number'),
+
+  param('locationId')
+    .isString()
+    .isUUID()
+    .withMessage('Location ID must be a valid UUID'),
+
+  body('notes')
+    .isString()
+    .notEmpty()
+    .withMessage('Notes are required and must be a non-empty string'),
+]);
+
+// Validation for Getting All Marked Locations for a Trip
+export const validateGetAllMarkedLocationsInput = checkExact([
+  param('tripId').isInt({ min: 1 }).withMessage('Trip ID must be a number'),
+]);
+
+// Validation for Deleting a Marked Location
+export const validateDeleteMarkedLocationInput = checkExact([
+  param('tripId').isInt({ min: 1 }).withMessage('Trip ID must be a number'),
+
+  param('locationId')
+    .isString()
+    .isUUID()
+    .withMessage('Location ID must be a valid UUID'),
+]);

--- a/server/src/models/markedLocation.model.ts
+++ b/server/src/models/markedLocation.model.ts
@@ -1,6 +1,6 @@
 import prisma from '@/config/prismaClient.js';
 import { handlePrismaError } from '@/utils/errorHandlers.js';
-import { NotFoundError, ForbiddenError } from '@/utils/errors.js';
+import { NotFoundError } from '@/utils/errors.js';
 import { CreateMarkedLocationInput } from '@/interfaces/interfaces.js';
 
 // Create a Marked Location

--- a/server/src/models/markedLocation.model.ts
+++ b/server/src/models/markedLocation.model.ts
@@ -1,20 +1,12 @@
 import prisma from '@/config/prismaClient.js';
 import { handlePrismaError } from '@/utils/errorHandlers.js';
 import { NotFoundError, ForbiddenError } from '@/utils/errors.js';
-import { LocationType } from '@prisma/client';
+import { CreateMarkedLocationInput } from '@/interfaces/interfaces.js';
 
 // Create a Marked Location
-export const createMarkedLocation = async (locationData: {
-  tripId: number;
-  name: string;
-  type: LocationType;
-  coordinates: { latitude: number; longitude: number };
-  address?: string;
-  createdById: string;
-  notes?: string;
-  website?: string;
-  phoneNumber?: string;
-}) => {
+export const createMarkedLocation = async (
+  locationData: CreateMarkedLocationInput,
+) => {
   try {
     return await prisma.markedLocation.create({
       data: locationData,
@@ -26,23 +18,8 @@ export const createMarkedLocation = async (locationData: {
 };
 
 // Get all Marked Locations for a Trip
-export const getAllMarkedLocationsForTrip = async (
-  tripId: number,
-  userId: string,
-) => {
+export const getAllMarkedLocationsForTrip = async (tripId: number) => {
   try {
-    // Check if user is a member of the trip
-    const member = await prisma.tripMember.findFirst({
-      where: {
-        tripId,
-        userId,
-      },
-    });
-
-    if (!member) {
-      throw new ForbiddenError('You are not a member of this trip');
-    }
-
     return await prisma.markedLocation.findMany({
       where: {
         tripId,

--- a/server/src/models/markedLocation.model.ts
+++ b/server/src/models/markedLocation.model.ts
@@ -1,0 +1,175 @@
+import prisma from '@/config/prismaClient.js';
+import { handlePrismaError } from '@/utils/errorHandlers.js';
+import { NotFoundError, ForbiddenError } from '@/utils/errors.js';
+import { LocationType } from '@prisma/client';
+
+// Create a Marked Location
+export const createMarkedLocation = async (locationData: {
+  tripId: number;
+  name: string;
+  type: LocationType;
+  coordinates: { latitude: number; longitude: number };
+  address?: string;
+  createdById: string;
+  notes?: string;
+  website?: string;
+  phoneNumber?: string;
+}) => {
+  try {
+    return await prisma.markedLocation.create({
+      data: locationData,
+    });
+  } catch (error) {
+    console.error('Error creating marked location:', error);
+    throw handlePrismaError(error);
+  }
+};
+
+// Get all Marked Locations for a Trip
+export const getAllMarkedLocationsForTrip = async (
+  tripId: number,
+  userId: string,
+) => {
+  try {
+    // Check if user is a member of the trip
+    const member = await prisma.tripMember.findFirst({
+      where: {
+        tripId,
+        userId,
+      },
+    });
+
+    if (!member) {
+      throw new ForbiddenError('You are not a member of this trip');
+    }
+
+    return await prisma.markedLocation.findMany({
+      where: {
+        tripId,
+      },
+      include: {
+        createdBy: {
+          select: {
+            id: true,
+            fullName: true,
+            email: true,
+          },
+        },
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+    });
+  } catch (error) {
+    console.error('Error fetching marked locations:', error);
+    throw handlePrismaError(error);
+  }
+};
+
+// Get a single Marked Location by ID
+export const getMarkedLocationById = async (
+  tripId: number,
+  locationId: string,
+  userId: string,
+) => {
+  try {
+    // Check if user is a member of the trip
+    const member = await prisma.tripMember.findFirst({
+      where: {
+        tripId,
+        userId,
+      },
+    });
+
+    if (!member) {
+      throw new ForbiddenError('You are not a member of this trip');
+    }
+
+    const location = await prisma.markedLocation.findUnique({
+      where: {
+        id: locationId,
+        tripId,
+      },
+      include: {
+        createdBy: {
+          select: {
+            id: true,
+            fullName: true,
+            email: true,
+          },
+        },
+      },
+    });
+
+    if (!location) {
+      throw new NotFoundError('Marked location not found');
+    }
+
+    return location;
+  } catch (error) {
+    console.error('Error fetching marked location:', error);
+    throw handlePrismaError(error);
+  }
+};
+
+// Update the notes field of a Marked Location
+export const updateMarkedLocationNotes = async (
+  locationId: string,
+  notes: string,
+) => {
+  try {
+    return await prisma.markedLocation.update({
+      where: {
+        id: locationId,
+      },
+      data: {
+        notes,
+      },
+    });
+  } catch (error) {
+    console.error('Error updating marked location notes:', error);
+    throw handlePrismaError(error);
+  }
+};
+
+// Delete a Marked Location
+export const deleteMarkedLocation = async (
+  tripId: number,
+  locationId: string,
+  userId: string,
+) => {
+  try {
+    // Check if the location exists and belongs to the specified trip
+    const location = await prisma.markedLocation.findUnique({
+      where: {
+        id: locationId,
+        tripId,
+      },
+    });
+
+    if (!location) {
+      throw new NotFoundError('Marked location not found');
+    }
+
+    // Check if user is a member of the trip
+    const member = await prisma.tripMember.findFirst({
+      where: {
+        tripId,
+        userId,
+      },
+    });
+
+    if (!member) {
+      throw new ForbiddenError('You are not a member of this trip');
+    }
+
+    return await prisma.markedLocation.delete({
+      where: {
+        id: locationId,
+      },
+    });
+  } catch (error) {
+    console.error('Error deleting marked location:', error);
+    throw handlePrismaError(error);
+  }
+};

--- a/server/src/models/markedLocation.model.ts
+++ b/server/src/models/markedLocation.model.ts
@@ -47,21 +47,8 @@ export const getAllMarkedLocationsForTrip = async (tripId: number) => {
 export const getMarkedLocationById = async (
   tripId: number,
   locationId: string,
-  userId: string,
 ) => {
   try {
-    // Check if user is a member of the trip
-    const member = await prisma.tripMember.findFirst({
-      where: {
-        tripId,
-        userId,
-      },
-    });
-
-    if (!member) {
-      throw new ForbiddenError('You are not a member of this trip');
-    }
-
     const location = await prisma.markedLocation.findUnique({
       where: {
         id: locationId,
@@ -110,36 +97,8 @@ export const updateMarkedLocationNotes = async (
 };
 
 // Delete a Marked Location
-export const deleteMarkedLocation = async (
-  tripId: number,
-  locationId: string,
-  userId: string,
-) => {
+export const deleteMarkedLocation = async (locationId: string) => {
   try {
-    // Check if the location exists and belongs to the specified trip
-    const location = await prisma.markedLocation.findUnique({
-      where: {
-        id: locationId,
-        tripId,
-      },
-    });
-
-    if (!location) {
-      throw new NotFoundError('Marked location not found');
-    }
-
-    // Check if user is a member of the trip
-    const member = await prisma.tripMember.findFirst({
-      where: {
-        tripId,
-        userId,
-      },
-    });
-
-    if (!member) {
-      throw new ForbiddenError('You are not a member of this trip');
-    }
-
     return await prisma.markedLocation.delete({
       where: {
         id: locationId,

--- a/server/src/routes/appRouter.ts
+++ b/server/src/routes/appRouter.ts
@@ -8,6 +8,7 @@ import messageRouter from '@/routes/message.routes.js';
 import pollRouter from '@/routes/poll.routes.js';
 import itineraryEventRouter from '@/routes/itineraryEvent.routes.js';
 import notificationRouter from '@/routes/notification.routes.js';
+import markedLocationRouter from '@/routes/markedLocation.routes.js';
 import { authMiddleware } from '@/middleware/authMiddleware.js';
 
 const router = express.Router();
@@ -32,5 +33,6 @@ router.use('/trips/:tripId/members', memberRouter);
 router.use('/trips/:tripId/messages', messageRouter);
 router.use('/trips/:tripId/polls', pollRouter);
 router.use('/trips/:tripId/itinerary-events', itineraryEventRouter);
+router.use('/trips/:tripId/marked-locations', markedLocationRouter);
 
 export default router;

--- a/server/src/routes/markedLocation.routes.ts
+++ b/server/src/routes/markedLocation.routes.ts
@@ -1,0 +1,51 @@
+import express from 'express';
+import {
+  createMarkedLocationHandler,
+  getAllMarkedLocationsHandler,
+  updateMarkedLocationNotesHandler,
+  deleteMarkedLocationHandler,
+} from '@/controllers/markedLocation.controller.js';
+import {
+  validateCreateMarkedLocationInput,
+  validateGetAllMarkedLocationsInput,
+  validateUpdateMarkedLocationNotesInput,
+  validateDeleteMarkedLocationInput,
+} from '@/middleware/markedLocation.validators.js';
+import validationErrorHandler from '@/middleware/validationErrorHandler.js';
+
+const router = express.Router({ mergeParams: true });
+
+router
+  // Get all marked locations for a trip
+  .get(
+    '/',
+    validateGetAllMarkedLocationsInput,
+    validationErrorHandler,
+    getAllMarkedLocationsHandler,
+  )
+
+  // Create a new marked location
+  .post(
+    '/',
+    validateCreateMarkedLocationInput,
+    validationErrorHandler,
+    createMarkedLocationHandler,
+  )
+
+  // Update the notes of a marked location
+  .patch(
+    '/:locationId/notes',
+    validateUpdateMarkedLocationNotesInput,
+    validationErrorHandler,
+    updateMarkedLocationNotesHandler,
+  )
+
+  // Delete a marked location
+  .delete(
+    '/:locationId',
+    validateDeleteMarkedLocationInput,
+    validationErrorHandler,
+    deleteMarkedLocationHandler,
+  );
+
+export default router;

--- a/server/src/routes/markedLocation.routes.ts
+++ b/server/src/routes/markedLocation.routes.ts
@@ -33,7 +33,7 @@ router
   )
 
   // Update the notes of a marked location
-  .patch(
+  .put(
     '/:locationId/notes',
     validateUpdateMarkedLocationNotesInput,
     validationErrorHandler,

--- a/server/src/tests/unit/markedLocation.tests/markedLocation.controller.test.ts
+++ b/server/src/tests/unit/markedLocation.tests/markedLocation.controller.test.ts
@@ -1,0 +1,179 @@
+import {
+  createMarkedLocationHandler,
+  getAllMarkedLocationsHandler,
+  updateMarkedLocationNotesHandler,
+  deleteMarkedLocationHandler,
+} from '@/controllers/markedLocation.controller.js';
+import prisma from '@/config/prismaClient.js';
+import { Request, Response } from 'express';
+import { LocationType } from '@prisma/client';
+
+jest.mock('@/config/prismaClient.js', () => ({
+  __esModule: true,
+  default: {
+    tripMember: {
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+    },
+    markedLocation: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+  },
+}));
+
+describe('MarkedLocation API - Create Location', () => {
+  let mockReq: Partial<Request>;
+  let mockRes: Partial<Response>;
+  let statusMock: jest.Mock;
+  let jsonMock: jest.Mock;
+
+  beforeEach(() => {
+    jsonMock = jest.fn();
+    statusMock = jest.fn().mockReturnValue({ json: jsonMock });
+
+    mockRes = {
+      status: statusMock,
+      json: jsonMock,
+    } as Partial<Response>;
+
+    jest.clearAllMocks();
+  });
+
+  const setupRequest = (overrides = {}) => ({
+    userId: 'test-user-id',
+    params: { tripId: '1' },
+    body: {
+      name: 'Great Restaurant',
+      type: 'RESTAURANT',
+      coordinates: { latitude: 37.7749, longitude: -122.4194 },
+      address: '123 Main St, San Francisco, CA',
+      notes: 'Great place for dinner',
+      website: 'https://example.com',
+      phoneNumber: '123-456-7890',
+    },
+    ...overrides,
+  });
+
+  it('should create a marked location successfully', async () => {
+    mockReq = setupRequest();
+    const fakeLocation = {
+      id: '550e8400-e29b-41d4-a716-446655440000',
+      ...mockReq.body,
+      createdById: 'test-user-id',
+      tripId: 1,
+      type: LocationType.RESTAURANT,
+    };
+
+    (prisma.tripMember.findUnique as jest.Mock).mockResolvedValue({
+      userId: 'test-user-id',
+      tripId: 1,
+      role: 'member',
+    });
+    (prisma.markedLocation.create as jest.Mock).mockResolvedValue(fakeLocation);
+
+    await createMarkedLocationHandler(mockReq as Request, mockRes as Response);
+
+    expect(statusMock).toHaveBeenCalledWith(201);
+    expect(jsonMock).toHaveBeenCalledWith({
+      message: 'Marked location created successfully',
+      markedLocation: fakeLocation,
+    });
+  });
+
+  it('should return 401 if user is not authenticated', async () => {
+    mockReq = setupRequest({ userId: undefined });
+
+    await createMarkedLocationHandler(mockReq as Request, mockRes as Response);
+
+    expect(statusMock).toHaveBeenCalledWith(401);
+    expect(jsonMock).toHaveBeenCalledWith({ error: 'Unauthorized Request' });
+  });
+
+  it('should return 400 if tripId is invalid', async () => {
+    mockReq = setupRequest({
+      params: { tripId: 'invalid' },
+    });
+
+    await createMarkedLocationHandler(mockReq as Request, mockRes as Response);
+
+    expect(statusMock).toHaveBeenCalledWith(400);
+    expect(jsonMock).toHaveBeenCalledWith({ error: 'Invalid trip ID' });
+  });
+
+  it('should return 403 if user is not a member of the trip', async () => {
+    mockReq = setupRequest();
+
+    (prisma.tripMember.findUnique as jest.Mock).mockResolvedValue(null);
+
+    await createMarkedLocationHandler(mockReq as Request, mockRes as Response);
+
+    expect(statusMock).toHaveBeenCalledWith(403);
+    expect(jsonMock).toHaveBeenCalledWith({
+      error: 'You are not a member of this trip: 1',
+    });
+  });
+
+  it('should handle an invalid location type gracefully', async () => {
+    mockReq = setupRequest({
+      body: {
+        name: 'Great Restaurant',
+        type: 'INVALID_TYPE', // Invalid type
+        coordinates: { latitude: 37.7749, longitude: -122.4194 },
+      },
+    });
+
+    (prisma.tripMember.findUnique as jest.Mock).mockResolvedValue({
+      userId: 'test-user-id',
+      tripId: 1,
+      role: 'member',
+    });
+
+    const fakeLocation = {
+      id: '550e8400-e29b-41d4-a716-446655440000',
+      name: 'Great Restaurant',
+      type: LocationType.OTHER, // Should default to OTHER
+      coordinates: { latitude: 37.7749, longitude: -122.4194 },
+      createdById: 'test-user-id',
+      tripId: 1,
+    };
+
+    (prisma.markedLocation.create as jest.Mock).mockResolvedValue(fakeLocation);
+
+    await createMarkedLocationHandler(mockReq as Request, mockRes as Response);
+
+    expect(statusMock).toHaveBeenCalledWith(201);
+    expect(jsonMock).toHaveBeenCalledWith({
+      message: 'Marked location created successfully',
+      markedLocation: fakeLocation,
+    });
+
+    expect(prisma.markedLocation.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: LocationType.OTHER,
+        }),
+      }),
+    );
+  });
+
+  it('should return 500 on prismadatabase error', async () => {
+    mockReq = setupRequest();
+
+    (prisma.tripMember.findUnique as jest.Mock).mockRejectedValue(
+      new Error('Database error'),
+    );
+
+    await createMarkedLocationHandler(mockReq as Request, mockRes as Response);
+
+    expect(statusMock).toHaveBeenCalledWith(500);
+    expect(jsonMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.stringContaining('An unexpected database error occurred.'),
+      }),
+    );
+  });
+});

--- a/server/src/tests/unit/markedLocation.tests/markedLocation.controller.test.ts
+++ b/server/src/tests/unit/markedLocation.tests/markedLocation.controller.test.ts
@@ -346,7 +346,7 @@ describe('MarkedLocation API - Update Location Notes', () => {
     ...overrides,
   });
 
-  it('should update location notes successfully as marker creator', async () => {
+  it('should update location notes successfully as a trip member', async () => {
     mockReq = setupRequest();
     const fakeLocation = {
       id: '550e8400-e29b-41d4-a716-446655440000',
@@ -381,114 +381,6 @@ describe('MarkedLocation API - Update Location Notes', () => {
     expect(jsonMock).toHaveBeenCalledWith({
       message: 'Marked location notes updated successfully',
       updatedLocation,
-    });
-  });
-
-  it('should update location notes successfully as trip admin', async () => {
-    mockReq = setupRequest();
-    const fakeLocation = {
-      id: '550e8400-e29b-41d4-a716-446655440000',
-      name: 'Great Restaurant',
-      type: LocationType.RESTAURANT,
-      coordinates: { latitude: 37.7749, longitude: -122.4194 },
-      notes: 'Original notes',
-      createdById: 'other-user-id',
-      tripId: 1,
-    };
-
-    const updatedLocation = {
-      ...fakeLocation,
-      notes: 'Updated notes for the location',
-    };
-
-    (getTripMember as jest.Mock).mockResolvedValue({
-      userId: 'test-user-id',
-      tripId: 1,
-      role: 'admin', // Admin can update any marker
-    });
-
-    (getMarkedLocationById as jest.Mock).mockResolvedValue(fakeLocation);
-    (updateMarkedLocationNotes as jest.Mock).mockResolvedValue(updatedLocation);
-
-    await updateMarkedLocationNotesHandler(
-      mockReq as Request,
-      mockRes as Response,
-    );
-
-    expect(statusMock).toHaveBeenCalledWith(200);
-    expect(jsonMock).toHaveBeenCalledWith({
-      message: 'Marked location notes updated successfully',
-      updatedLocation,
-    });
-  });
-
-  it('should update location notes successfully as trip creator', async () => {
-    mockReq = setupRequest();
-    const fakeLocation = {
-      id: '550e8400-e29b-41d4-a716-446655440000',
-      name: 'Great Restaurant',
-      type: LocationType.RESTAURANT,
-      coordinates: { latitude: 37.7749, longitude: -122.4194 },
-      notes: 'Original notes',
-      createdById: 'other-user-id',
-      tripId: 1,
-    };
-
-    const updatedLocation = {
-      ...fakeLocation,
-      notes: 'Updated notes for the location',
-    };
-
-    (getTripMember as jest.Mock).mockResolvedValue({
-      userId: 'test-user-id',
-      tripId: 1,
-      role: 'creator',
-    });
-
-    (getMarkedLocationById as jest.Mock).mockResolvedValue(fakeLocation);
-    (updateMarkedLocationNotes as jest.Mock).mockResolvedValue(updatedLocation);
-
-    await updateMarkedLocationNotesHandler(
-      mockReq as Request,
-      mockRes as Response,
-    );
-
-    expect(statusMock).toHaveBeenCalledWith(200);
-    expect(jsonMock).toHaveBeenCalledWith({
-      message: 'Marked location notes updated successfully',
-      updatedLocation,
-    });
-  });
-
-  it('should return 403 if user is not marker creator, admin, or trip creator', async () => {
-    mockReq = setupRequest();
-    const fakeLocation = {
-      id: '550e8400-e29b-41d4-a716-446655440000',
-      name: 'Great Restaurant',
-      type: LocationType.RESTAURANT,
-      coordinates: { latitude: 37.7749, longitude: -122.4194 },
-      notes: 'Original notes',
-      createdById: 'other-user-id', // Different from userId in request
-      tripId: 1,
-    };
-
-    (getTripMember as jest.Mock).mockResolvedValue({
-      userId: 'test-user-id',
-      tripId: 1,
-      role: 'member', // Regular member, not creator or admin
-    });
-
-    (getMarkedLocationById as jest.Mock).mockResolvedValue(fakeLocation);
-
-    await updateMarkedLocationNotesHandler(
-      mockReq as Request,
-      mockRes as Response,
-    );
-
-    expect(statusMock).toHaveBeenCalledWith(403);
-    expect(jsonMock).toHaveBeenCalledWith({
-      error:
-        'Only the marker creator, trip admins, and trip creators can update marked locations',
     });
   });
 

--- a/server/src/tests/unit/markedLocation.tests/markedLocation.validator.test.ts
+++ b/server/src/tests/unit/markedLocation.tests/markedLocation.validator.test.ts
@@ -1,0 +1,241 @@
+import {
+  validateCreateMarkedLocationInput,
+  validateUpdateMarkedLocationNotesInput,
+  validateGetAllMarkedLocationsInput,
+  validateDeleteMarkedLocationInput,
+} from '@/middleware/markedLocation.validators.js';
+import { validationResult } from 'express-validator';
+import { Request } from 'express';
+import { LocationType } from '@prisma/client';
+
+describe('MarkedLocation Validators Middleware', () => {
+  let mockReq: Partial<Request>;
+
+  const runValidation = async (req: Partial<Request>, validation: any) => {
+    await validation.run(req);
+    return validationResult(req);
+  };
+
+  /** ───────────────────────────────────────────────────────
+   * CREATE MARKED LOCATION VALIDATION TESTS
+   * ─────────────────────────────────────────────────────── */
+  describe('Create Marked Location Validation', () => {
+    it('should pass validation for a valid input', async () => {
+      mockReq = {
+        params: { tripId: '1' },
+        body: {
+          name: 'Great Restaurant',
+          type: 'RESTAURANT',
+          coordinates: { latitude: 37.7749, longitude: -122.4194 },
+          address: '123 Main St, San Francisco, CA',
+          notes: 'Great place for dinner',
+          website: 'https://example.com',
+          phoneNumber: '123-456-7890',
+        },
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateCreateMarkedLocationInput,
+      );
+      expect(result.isEmpty()).toBe(true);
+    });
+
+    it('should fail validation if tripId is not a number', async () => {
+      mockReq = {
+        params: { tripId: 'abc' },
+        body: {
+          name: 'Great Restaurant',
+          type: 'RESTAURANT',
+          coordinates: { latitude: 37.7749, longitude: -122.4194 },
+        },
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateCreateMarkedLocationInput,
+      );
+      expect(result.isEmpty()).toBe(false);
+      expect(result.array()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ msg: 'Trip ID must be a number' }),
+        ]),
+      );
+    });
+
+    it('should fail validation if name is missing', async () => {
+      mockReq = {
+        params: { tripId: '1' },
+        body: {
+          type: 'RESTAURANT',
+          coordinates: { latitude: 37.7749, longitude: -122.4194 },
+        },
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateCreateMarkedLocationInput,
+      );
+      expect(result.isEmpty()).toBe(false);
+      expect(result.array()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ msg: 'Name is required' }),
+        ]),
+      );
+    });
+
+    it('should fail validation if type is missing', async () => {
+      mockReq = {
+        params: { tripId: '1' },
+        body: {
+          name: 'Great Restaurant',
+          coordinates: { latitude: 37.7749, longitude: -122.4194 },
+        },
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateCreateMarkedLocationInput,
+      );
+      expect(result.isEmpty()).toBe(false);
+      expect(result.array()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ msg: 'Type is required' }),
+        ]),
+      );
+    });
+
+    it('should fail validation if type is invalid', async () => {
+      mockReq = {
+        params: { tripId: '1' },
+        body: {
+          name: 'Great Restaurant',
+          type: 'INVALID_TYPE', // Invalid type
+          coordinates: { latitude: 37.7749, longitude: -122.4194 },
+        },
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateCreateMarkedLocationInput,
+      );
+      expect(result.isEmpty()).toBe(false);
+      expect(result.array()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            msg: expect.stringContaining('Invalid type. Allowed values:'),
+          }),
+        ]),
+      );
+    });
+
+    it('should fail validation if coordinates are missing', async () => {
+      mockReq = {
+        params: { tripId: '1' },
+        body: {
+          name: 'Great Restaurant',
+          type: 'RESTAURANT',
+        },
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateCreateMarkedLocationInput,
+      );
+      expect(result.isEmpty()).toBe(false);
+      expect(result.array()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ msg: 'Coordinates are required' }),
+        ]),
+      );
+    });
+
+    it('should fail validation if coordinates are invalid (out of range)', async () => {
+      mockReq = {
+        params: { tripId: '1' },
+        body: {
+          name: 'Great Restaurant',
+          type: 'RESTAURANT',
+          coordinates: { latitude: 100, longitude: -122.4194 }, // Latitude out of range
+        },
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateCreateMarkedLocationInput,
+      );
+      expect(result.isEmpty()).toBe(false);
+      expect(result.array()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            msg: 'Latitude and longitude values are out of range',
+          }),
+        ]),
+      );
+    });
+
+    it('should fail validation if coordinates are missing latitude or longitude', async () => {
+      mockReq = {
+        params: { tripId: '1' },
+        body: {
+          name: 'Great Restaurant',
+          type: 'RESTAURANT',
+          coordinates: { longitude: -122.4194 }, // Missing latitude
+        },
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateCreateMarkedLocationInput,
+      );
+      expect(result.isEmpty()).toBe(false);
+      expect(result.array()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            msg: 'Coordinates must include valid latitude and longitude numbers',
+          }),
+        ]),
+      );
+    });
+
+    it('should fail validation if website is invalid', async () => {
+      mockReq = {
+        params: { tripId: '1' },
+        body: {
+          name: 'Great Restaurant',
+          type: 'RESTAURANT',
+          coordinates: { latitude: 37.7749, longitude: -122.4194 },
+          website: 'not-a-valid-url',
+        },
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateCreateMarkedLocationInput,
+      );
+      expect(result.isEmpty()).toBe(false);
+      expect(result.array()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ msg: 'Website must be a valid URL' }),
+        ]),
+      );
+    });
+
+    it('should pass validation if optional fields are omitted', async () => {
+      mockReq = {
+        params: { tripId: '1' },
+        body: {
+          name: 'Great Restaurant',
+          type: 'RESTAURANT',
+          coordinates: { latitude: 37.7749, longitude: -122.4194 },
+        },
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateCreateMarkedLocationInput,
+      );
+      expect(result.isEmpty()).toBe(true);
+    });
+  });
+});

--- a/server/src/tests/unit/markedLocation.tests/markedLocation.validator.test.ts
+++ b/server/src/tests/unit/markedLocation.tests/markedLocation.validator.test.ts
@@ -237,7 +237,7 @@ describe('MarkedLocation Validators Middleware', () => {
     });
   });
 
-  // CREATE MARKED LOCATION VALIDATION TESTS
+  // UPDATE MARKED LOCATION VALIDATION TESTS
   describe('Update Marked Location Notes Validation', () => {
     it('should pass validation for valid input', async () => {
       mockReq = {
@@ -440,9 +440,8 @@ describe('MarkedLocation Validators Middleware', () => {
     });
   });
 
-  /** ───────────────────────────────────────────────────────
-   * DELETE MARKED LOCATION VALIDATION TESTS
-   * ─────────────────────────────────────────────────────── */
+
+// DELETE MARKED LOCATION VALIDATION TESTS
   describe('Delete Marked Location Validation', () => {
     it('should pass validation for valid input', async () => {
       mockReq = {

--- a/server/src/tests/unit/markedLocation.tests/markedLocation.validator.test.ts
+++ b/server/src/tests/unit/markedLocation.tests/markedLocation.validator.test.ts
@@ -238,4 +238,143 @@ describe('MarkedLocation Validators Middleware', () => {
       expect(result.isEmpty()).toBe(true);
     });
   });
+
+  /** ───────────────────────────────────────────────────────
+   * UPDATE MARKED LOCATION NOTES VALIDATION TESTS
+   * ─────────────────────────────────────────────────────── */
+  describe('Update Marked Location Notes Validation', () => {
+    it('should pass validation for valid input', async () => {
+      mockReq = {
+        params: {
+          tripId: '1',
+          locationId: '550e8400-e29b-41d4-a716-446655440000',
+        },
+        body: {
+          notes: 'Updated notes for the location',
+        },
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateUpdateMarkedLocationNotesInput,
+      );
+      expect(result.isEmpty()).toBe(true);
+    });
+
+    it('should fail validation if tripId is not a number', async () => {
+      mockReq = {
+        params: {
+          tripId: 'abc',
+          locationId: '550e8400-e29b-41d4-a716-446655440000',
+        },
+        body: {
+          notes: 'Updated notes for the location',
+        },
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateUpdateMarkedLocationNotesInput,
+      );
+      expect(result.isEmpty()).toBe(false);
+      expect(result.array()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ msg: 'Trip ID must be a number' }),
+        ]),
+      );
+    });
+
+    it('should fail validation if locationId is not a UUID', async () => {
+      mockReq = {
+        params: { tripId: '1', locationId: 'not-a-uuid' },
+        body: {
+          notes: 'Updated notes for the location',
+        },
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateUpdateMarkedLocationNotesInput,
+      );
+      expect(result.isEmpty()).toBe(false);
+      expect(result.array()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ msg: 'Location ID must be a valid UUID' }),
+        ]),
+      );
+    });
+
+    it('should fail validation if notes are missing', async () => {
+      mockReq = {
+        params: {
+          tripId: '1',
+          locationId: '550e8400-e29b-41d4-a716-446655440000',
+        },
+        body: {},
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateUpdateMarkedLocationNotesInput,
+      );
+      expect(result.isEmpty()).toBe(false);
+      expect(result.array()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            msg: 'Notes are required and must be a non-empty string',
+          }),
+        ]),
+      );
+    });
+
+    it('should fail validation if notes are empty', async () => {
+      mockReq = {
+        params: {
+          tripId: '1',
+          locationId: '550e8400-e29b-41d4-a716-446655440000',
+        },
+        body: {
+          notes: '',
+        },
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateUpdateMarkedLocationNotesInput,
+      );
+      expect(result.isEmpty()).toBe(false);
+      expect(result.array()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            msg: 'Notes are required and must be a non-empty string',
+          }),
+        ]),
+      );
+    });
+
+    it('should fail validation if notes are not a string', async () => {
+      mockReq = {
+        params: {
+          tripId: '1',
+          locationId: '550e8400-e29b-41d4-a716-446655440000',
+        },
+        body: {
+          notes: 123, // Not a string
+        },
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateUpdateMarkedLocationNotesInput,
+      );
+      expect(result.isEmpty()).toBe(false);
+      expect(result.array()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            msg: 'Invalid value',
+          }),
+        ]),
+      );
+    });
+  });
 });

--- a/server/src/tests/unit/markedLocation.tests/markedLocation.validator.test.ts
+++ b/server/src/tests/unit/markedLocation.tests/markedLocation.validator.test.ts
@@ -16,9 +16,7 @@ describe('MarkedLocation Validators Middleware', () => {
     return validationResult(req);
   };
 
-  /** ───────────────────────────────────────────────────────
-   * CREATE MARKED LOCATION VALIDATION TESTS
-   * ─────────────────────────────────────────────────────── */
+  // CREATE MARKED LOCATION VALIDATION TESTS
   describe('Create Marked Location Validation', () => {
     it('should pass validation for a valid input', async () => {
       mockReq = {
@@ -239,9 +237,7 @@ describe('MarkedLocation Validators Middleware', () => {
     });
   });
 
-  /** ───────────────────────────────────────────────────────
-   * UPDATE MARKED LOCATION NOTES VALIDATION TESTS
-   * ─────────────────────────────────────────────────────── */
+  // CREATE MARKED LOCATION VALIDATION TESTS
   describe('Update Marked Location Notes Validation', () => {
     it('should pass validation for valid input', async () => {
       mockReq = {
@@ -373,6 +369,164 @@ describe('MarkedLocation Validators Middleware', () => {
           expect.objectContaining({
             msg: 'Invalid value',
           }),
+        ]),
+      );
+    });
+  });
+
+  // GET ALL MARKED LOCATION VALIDATION TESTS
+  describe('Get All Marked Locations Validation', () => {
+    it('should pass validation for valid tripId', async () => {
+      mockReq = {
+        params: { tripId: '1' },
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateGetAllMarkedLocationsInput,
+      );
+      expect(result.isEmpty()).toBe(true);
+    });
+
+    it('should fail validation if tripId is not a number', async () => {
+      mockReq = {
+        params: { tripId: 'abc' },
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateGetAllMarkedLocationsInput,
+      );
+      expect(result.isEmpty()).toBe(false);
+      expect(result.array()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ msg: 'Trip ID must be a number' }),
+        ]),
+      );
+    });
+
+    it('should fail validation if tripId is negative', async () => {
+      mockReq = {
+        params: { tripId: '-5' },
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateGetAllMarkedLocationsInput,
+      );
+      expect(result.isEmpty()).toBe(false);
+      expect(result.array()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ msg: 'Trip ID must be a number' }),
+        ]),
+      );
+    });
+
+    it('should fail validation if tripId is missing', async () => {
+      mockReq = {
+        params: {},
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateGetAllMarkedLocationsInput,
+      );
+      expect(result.isEmpty()).toBe(false);
+      expect(result.array()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ msg: 'Trip ID must be a number' }),
+        ]),
+      );
+    });
+  });
+
+  /** ───────────────────────────────────────────────────────
+   * DELETE MARKED LOCATION VALIDATION TESTS
+   * ─────────────────────────────────────────────────────── */
+  describe('Delete Marked Location Validation', () => {
+    it('should pass validation for valid input', async () => {
+      mockReq = {
+        params: {
+          tripId: '1',
+          locationId: '550e8400-e29b-41d4-a716-446655440000',
+        },
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateDeleteMarkedLocationInput,
+      );
+      expect(result.isEmpty()).toBe(true);
+    });
+
+    it('should fail validation if tripId is not a number', async () => {
+      mockReq = {
+        params: {
+          tripId: 'abc',
+          locationId: '550e8400-e29b-41d4-a716-446655440000',
+        },
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateDeleteMarkedLocationInput,
+      );
+      expect(result.isEmpty()).toBe(false);
+      expect(result.array()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ msg: 'Trip ID must be a number' }),
+        ]),
+      );
+    });
+
+    it('should fail validation if locationId is not a UUID', async () => {
+      mockReq = {
+        params: { tripId: '1', locationId: 'not-a-uuid' },
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateDeleteMarkedLocationInput,
+      );
+      expect(result.isEmpty()).toBe(false);
+      expect(result.array()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ msg: 'Location ID must be a valid UUID' }),
+        ]),
+      );
+    });
+
+    it('should fail validation if locationId is missing', async () => {
+      mockReq = {
+        params: { tripId: '1' },
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateDeleteMarkedLocationInput,
+      );
+      expect(result.isEmpty()).toBe(false);
+      expect(result.array()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ msg: 'Location ID must be a valid UUID' }),
+        ]),
+      );
+    });
+
+    it('should fail validation if both tripId and locationId are invalid', async () => {
+      mockReq = {
+        params: { tripId: 'abc', locationId: 'not-a-uuid' },
+      };
+
+      const result = await runValidation(
+        mockReq,
+        validateDeleteMarkedLocationInput,
+      );
+      expect(result.isEmpty()).toBe(false);
+      expect(result.array()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ msg: 'Trip ID must be a number' }),
+          expect.objectContaining({ msg: 'Location ID must be a valid UUID' }),
         ]),
       );
     });

--- a/server/src/tests/unit/markedLocation.tests/markedLocation.validator.test.ts
+++ b/server/src/tests/unit/markedLocation.tests/markedLocation.validator.test.ts
@@ -6,7 +6,6 @@ import {
 } from '@/middleware/markedLocation.validators.js';
 import { validationResult } from 'express-validator';
 import { Request } from 'express';
-import { LocationType } from '@prisma/client';
 
 describe('MarkedLocation Validators Middleware', () => {
   let mockReq: Partial<Request>;
@@ -440,8 +439,7 @@ describe('MarkedLocation Validators Middleware', () => {
     });
   });
 
-
-// DELETE MARKED LOCATION VALIDATION TESTS
+  // DELETE MARKED LOCATION VALIDATION TESTS
   describe('Delete Marked Location Validation', () => {
     it('should pass validation for valid input', async () => {
       mockReq = {


### PR DESCRIPTION
added CRUD API endpoints for marked-locations.

GET -> https://localhost:8000/api/trips/:tripId/marked-locations
POST -> https://localhost:8000/api/trips/:tripId/marked-locations
PUT -> https://localhost:8000/api/trips/:tripId/marked-locations/:locationId/notes
DELETE -> https://localhost:8000/api/trips/:tripId/marked-locations/:locationId

added tests for validators and controllers.